### PR TITLE
⚡ Optimize ResolveParameters by removing LINQ allocations

### DIFF
--- a/ManualDi.Sync/ManualDi.Sync.Benchmark/InvokeBenchmark.cs
+++ b/ManualDi.Sync/ManualDi.Sync.Benchmark/InvokeBenchmark.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using System;
+using ManualDi.Sync;
+
+namespace ManualDi.Sync.Benchmark;
+
+[MemoryDiagnoser]
+public class InvokeBenchmark
+{
+    private IDiContainer container;
+    private Action<int, string, IDiContainer> action;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        container = new DiContainerBindings()
+            .Install(b =>
+            {
+                b.Bind<int>().FromInstance(42);
+                b.Bind<string>().FromInstance("hello");
+            })
+            .Build();
+        action = (i, s, c) => { };
+    }
+
+    [Benchmark]
+    public object InvokeDelegate()
+    {
+        return container.InvokeDelegateUsingReflexion(action);
+    }
+}

--- a/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
@@ -32,42 +32,50 @@ namespace ManualDi.Sync
 
         private static object?[] ResolveParameters(IDiContainer diContainer, Delegate @delegate)
         {
-            return @delegate.Method.GetParameters()
-                .Select(parameter =>
+            var parameters = @delegate.Method.GetParameters();
+            var arguments = new object?[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+                var type = parameter.ParameterType;
+                var underlyingType = Nullable.GetUnderlyingType(type);
+                var resolutionType = underlyingType ?? type;
+
+                if (resolutionType == typeof(IDiContainer))
                 {
-                    var type = parameter.ParameterType;
-                    var underlyingType = Nullable.GetUnderlyingType(type);
-                    var resolutionType = underlyingType ?? type;
+                    arguments[i] = diContainer;
+                    continue;
+                }
 
-                    if (resolutionType == typeof(IDiContainer))
-                    {
-                        return diContainer;
-                    }
+                if (resolutionType == typeof(CancellationToken))
+                {
+                    arguments[i] = diContainer.CancellationToken;
+                    continue;
+                }
 
-                    if (resolutionType == typeof(CancellationToken))
-                    {
-                        return diContainer.CancellationToken;
-                    }
-                    
-                    var filter = CreateFilterForParameter(parameter);
+                var filter = CreateFilterForParameter(parameter);
 
-                    var resolution = filter is null
-                        ? diContainer.ResolveContainer(resolutionType)
-                        : diContainer.ResolveContainer(resolutionType, filter);
+                var resolution = filter is null
+                    ? diContainer.ResolveContainer(resolutionType)
+                    : diContainer.ResolveContainer(resolutionType, filter);
 
-                    if (resolution is not null)
-                    {
-                        return resolution;
-                    }
+                if (resolution is not null)
+                {
+                    arguments[i] = resolution;
+                    continue;
+                }
 
-                    if (IsNullable(parameter))
-                    {
-                        return null;
-                    }
+                if (IsNullable(parameter))
+                {
+                    arguments[i] = null;
+                    continue;
+                }
 
-                    throw new InvalidOperationException($"Could not resolve element of type {type.FullName} for parameter {parameter.Name}");
-                })
-                .ToArray();
+                throw new InvalidOperationException($"Could not resolve element of type {type.FullName} for parameter {parameter.Name}");
+            }
+
+            return arguments;
         }
 
         private static FilterBindingDelegate? CreateFilterForParameter(ParameterInfo parameter)


### PR DESCRIPTION
## ⚡ Performance Optimization

### 💡 What:
Replaced LINQ-based parameter resolution in `ManualDi.Sync.DiContainerInvokeExtensions.ResolveParameters` with a manual `for` loop and a pre-allocated `object?[]`.

### 🎯 Why:
The original implementation used LINQ `.Select().ToArray()`, which introduces unnecessary heap allocations for the LINQ iterator and intermediate buffers. Since this method is part of the dependency injection "hot path" (especially when using reflection-based invocation), reducing these allocations directly improves overall container performance and reduces GC pressure.

### 📊 Measured Improvement:
While numerical benchmark results could not be obtained due to environment timeouts (approx. 400s), this optimization follows standard .NET performance best practices for high-performance libraries. By eliminating LINQ overhead, the method now performs the minimum necessary work: one array allocation for the parameters (via reflection) and one array allocation for the resolved arguments.

A new benchmark file, `InvokeBenchmark.cs`, has been added to the `ManualDi.Sync.Benchmark` project to enable future performance tracking of this specific code path.

### ✅ Verification:
- Code review was performed and confirmed the correctness of the manual loop implementation.
- The logic preserves all existing behaviors, including special type handling (IDiContainer, CancellationToken), filtered resolution, and nullability checks.
- Functional tests in `ManualDi.Sync.Tests` cover these scenarios.


---
*PR created automatically by Jules for task [12290548132037347226](https://jules.google.com/task/12290548132037347226) started by @PereViader*