### PR TITLE
feat(#105): Optimize dictionary insertion in DiContainerBindings

### DIFF
--- a/ManualDi.Async/ManualDi.Async/Building/DiContainerBindings.cs
+++ b/ManualDi.Async/ManualDi.Async/Building/DiContainerBindings.cs
@@ -44,12 +44,12 @@ namespace ManualDi.Async
             bindingCount++;
             
             var apparentType = type.TypeHandle.Value;
-            if (!bindingsByType.TryGetValue(apparentType, out var innerbinding)) //TODO: Maybe this is more efficient if we do a TryAdd instead (common case)
+            if (bindingsByType.TryAdd(apparentType, binding))
             {
-                bindingsByType.Add(apparentType, binding);
                 return;
             }
 
+            var innerbinding = bindingsByType[apparentType];
             while (innerbinding.NextBinding is not null)
             {
                 innerbinding = innerbinding.NextBinding;

--- a/ManualDi.Sync/ManualDi.Sync/Building/DiContainerBindings.cs
+++ b/ManualDi.Sync/ManualDi.Sync/Building/DiContainerBindings.cs
@@ -42,12 +42,12 @@ namespace ManualDi.Sync
         internal void AddBinding(Binding binding, Type type)
         {
             var typeIntPtr = type.TypeHandle.Value;
-            if (!bindingsByType.TryGetValue(typeIntPtr, out var innerBinding))
+            if (bindingsByType.TryAdd(typeIntPtr, binding))
             {
-                bindingsByType.Add(typeIntPtr, binding);
                 return;
             }
 
+            var innerBinding = bindingsByType[typeIntPtr];
             while (innerBinding.NextBinding is not null)
             {
                 innerBinding = innerBinding.NextBinding;


### PR DESCRIPTION
This change optimizes the `AddBinding` method in `DiContainerBindings` by replacing the `TryGetValue` and `Add` sequence with a single `TryAdd` call for the initial insertion. If `TryAdd` fails (indicating the key already exists), the existing binding is retrieved via the dictionary indexer for linked list traversal. This reduces the number of dictionary lookups from two to one in the most common scenario where a type is first being registered. The optimization was applied to both `ManualDi.Async` and `ManualDi.Sync` projects to maintain consistency.

---
*PR created automatically by Jules for task [10440484671639072704](https://jules.google.com/task/10440484671639072704) started by @PereViader*