### PR TITLE
🔒 Fix hardcoded git-bash executable path

### DIFF
--- a/ManualDi.Async.Unity3d/Assets/Tools/SyncUtilsCommonDll.cs
+++ b/ManualDi.Async.Unity3d/Assets/Tools/SyncUtilsCommonDll.cs
@@ -35,14 +35,16 @@ public static class SyncUtilsCommonDll
 
     static ProcessStartInfo GetProcessStartInfo()
     {
-        if (!File.Exists("C:/Program Files/Git/git-bash.exe"))
+        var gitBashPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", "git-bash.exe");
+
+        if (!File.Exists(gitBashPath))
         {
-            throw new InvalidOperationException("Could not find git bash at C:/Program Files/Git/git-bash.exe");
+            throw new InvalidOperationException($"Could not find git bash at {gitBashPath}");
         }
 
         return new ProcessStartInfo
         {
-            FileName = "C:/Program Files/Git/git-bash.exe",
+            FileName = gitBashPath,
             Arguments = Script + " --skip-unity3d",
             WorkingDirectory = RepositoryRootPath,
             UseShellExecute = false,

--- a/ManualDi.Sync.Unity3d/Assets/Tools/SyncUtilsCommonDll.cs
+++ b/ManualDi.Sync.Unity3d/Assets/Tools/SyncUtilsCommonDll.cs
@@ -35,14 +35,16 @@ public static class SyncUtilsCommonDll
 
     static ProcessStartInfo GetProcessStartInfo()
     {
-        if (!File.Exists("C:/Program Files/Git/git-bash.exe"))
+        var gitBashPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", "git-bash.exe");
+
+        if (!File.Exists(gitBashPath))
         {
-            throw new InvalidOperationException("Could not find git bash at C:/Program Files/Git/git-bash.exe");
+            throw new InvalidOperationException($"Could not find git bash at {gitBashPath}");
         }
 
         return new ProcessStartInfo
         {
-            FileName = "C:/Program Files/Git/git-bash.exe",
+            FileName = gitBashPath,
             Arguments = Script + " --skip-unity3d",
             WorkingDirectory = RepositoryRootPath,
             UseShellExecute = false,


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a hardcoded absolute path to `git-bash.exe` (`C:/Program Files/Git/git-bash.exe`) in the internal editor tool scripts `SyncUtilsCommonDll.cs` within both the `ManualDi.Async.Unity3d` and `ManualDi.Sync.Unity3d` projects.

⚠️ **Risk:** While having a low direct security impact due to its use in an internal workflow tool, relying on hardcoded paths with absolute drive letters creates brittleness and hygiene issues. An attacker gaining write access to the C drive could theoretically plant a malicious executable, though standard Windows protections typically guard the Program Files directory. Additionally, it breaks functionality for developers who might have installed Git or Windows on a different drive.

🛡️ **Solution:** Modified the path resolution to dynamically fetch the system's Program Files directory using `Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)`. This removes the hardcoded `C:/` drive dependency while preserving the intended simple developer workflow. This solution honors the original intent without requiring complex, >50 line cross-OS configuration logic.

---
*PR created automatically by Jules for task [2825649459649907868](https://jules.google.com/task/2825649459649907868) started by @PereViader*