### PR TITLE
Fix Scene Unload during Cancellation

### DIFF
--- a/ManualDi.Async.Unity3d/Assets/ManualDi.Async.Unity3d/Runtime/Extensions/BindingAsyncExtensions.cs
+++ b/ManualDi.Async.Unity3d/Assets/ManualDi.Async.Unity3d/Runtime/Extensions/BindingAsyncExtensions.cs
@@ -177,8 +177,16 @@ namespace ManualDi.Async.Unity3d
                 
                 c.QueueAsyncDispose(async () =>
                 {
-                    //TODO: Validate if we can unload this in the case of a cancellation where the scene is unloading before it has finished loading
-                    var operation = SceneManager.UnloadSceneAsync(scene)!;
+                    if (!asyncOperation.isDone)
+                    {
+                        await WaitAsyncOperation(asyncOperation, CancellationToken.None);
+                    }
+
+                    var operation = SceneManager.UnloadSceneAsync(scene);
+                    if (operation is null)
+                    {
+                        return;
+                    }
                     await WaitAsyncOperation(operation, CancellationToken.None);
                 });
 

--- a/ManualDi.Async.Unity3d/Assets/ManualDi.Async.Unity3d/Tests/TestBindingAsyncExtensions.cs
+++ b/ManualDi.Async.Unity3d/Assets/ManualDi.Async.Unity3d/Tests/TestBindingAsyncExtensions.cs
@@ -111,5 +111,55 @@ namespace ManualDi.Async.Unity3d.Tests.PlayMode
                 Assert.That(SceneManager.sceneCount, Is.EqualTo(1));
             });
         }
+
+        [UnityTest]
+        public IEnumerator FromLoadSceneAsyncGetComponentInChildren_Resolves_WhenNotCancelled()
+        {
+            yield return TestExtensions.Async(async ct =>
+            {
+                await using var container = await new DiContainerBindings().Install(b =>
+                {
+                    b.Bind<Image>().FromLoadSceneAsyncGetComponentInChildren(TestAssetReferences.Instance.SceneName);
+                }).Build(ct);
+
+                var image = container.Resolve<Image>();
+                Assert.IsNotNull(image);
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator FromLoadSceneAsyncGetComponentInChildren_Cancelled_DisposesProperly()
+        {
+            yield return TestExtensions.Async(async ct =>
+            {
+                try
+                {
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+                    await using var container = await new DiContainerBindings().Install(b =>
+                    {
+                        var binding = b.Bind<Image>()
+                            .FromLoadSceneAsyncGetComponentInChildren(TestAssetReferences.Instance.SceneName);
+
+                        //Intercept delegate and use it to cancel the token on the same frame after starting the load
+                        FromAsyncDelegate fromDelegate = binding.GetFromAsyncDelegateNullable()!;
+                        binding.FromMethodAsync((c, ct) =>
+                        {
+                            var task = fromDelegate(c, ct);
+                            cts.Cancel();
+                            return task;
+                        });
+
+                    }).Build(cts.Token);
+
+                    Assert.Fail("Because it is cancelled during loading, this should never happen");
+                }
+                catch (OperationCanceledException)
+                {
+                }
+
+                Assert.That(SceneManager.sceneCount, Is.EqualTo(1));
+            });
+        }
     }
 }

--- a/manualdi_test.sh
+++ b/manualdi_test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Find unity path or run dotnet test
-echo "Running dotnet test..."
-cd ManualDi.Async.Unity3d
-dotnet test

--- a/manualdi_test.sh
+++ b/manualdi_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Find unity path or run dotnet test
+echo "Running dotnet test..."
+cd ManualDi.Async.Unity3d
+dotnet test


### PR DESCRIPTION
Fix Scene Unload during Cancellation

Modified `FromLoadSceneAsyncGetComponentInChildren` in `BindingAsyncExtensions.cs` to ensure that an asynchronous load operation finishes before attempting to unload the scene when canceled. This mirrors the logic in `FromLoadSceneAsyncGetComponent` and prevents exceptions when a cancellation triggers before the scene is fully loaded. Also added two unit tests in `TestBindingAsyncExtensions.cs` to explicitly cover the cancellation logic and verify the container resolves appropriately when not canceled.

---
*PR created automatically by Jules for task [13394503787360056139](https://jules.google.com/task/13394503787360056139) started by @PereViader*