### PR TITLE
🧹 Optimize dictionary insertion in DiContainerBindings

### DIFF
--- a/ManualDi.Async/ManualDi.Async/Building/DiContainerBindings.cs
+++ b/ManualDi.Async/ManualDi.Async/Building/DiContainerBindings.cs
@@ -44,12 +44,12 @@ namespace ManualDi.Async
             bindingCount++;
             
             var apparentType = type.TypeHandle.Value;
-            if (!bindingsByType.TryGetValue(apparentType, out var innerbinding)) //TODO: Maybe this is more efficient if we do a TryAdd instead (common case)
+            if (bindingsByType.TryAdd(apparentType, binding))
             {
-                bindingsByType.Add(apparentType, binding);
                 return;
             }
 
+            var innerbinding = bindingsByType[apparentType];
             while (innerbinding.NextBinding is not null)
             {
                 innerbinding = innerbinding.NextBinding;

--- a/ManualDi.Sync/ManualDi.Sync/Building/DiContainerBindings.cs
+++ b/ManualDi.Sync/ManualDi.Sync/Building/DiContainerBindings.cs
@@ -42,12 +42,12 @@ namespace ManualDi.Sync
         internal void AddBinding(Binding binding, Type type)
         {
             var typeIntPtr = type.TypeHandle.Value;
-            if (!bindingsByType.TryGetValue(typeIntPtr, out var innerBinding))
+            if (bindingsByType.TryAdd(typeIntPtr, binding))
             {
-                bindingsByType.Add(typeIntPtr, binding);
                 return;
             }
 
+            var innerBinding = bindingsByType[typeIntPtr];
             while (innerBinding.NextBinding is not null)
             {
                 innerBinding = innerBinding.NextBinding;


### PR DESCRIPTION
This change improves the performance of dependency registration by reducing the number of dictionary lookups from two to one for the most frequent operation (adding a new binding for a type). 

Key changes:
- Replaced `TryGetValue` + `Add` with `TryAdd` in `ManualDi.Async/ManualDi.Async/Building/DiContainerBindings.cs`.
- Replaced `TryGetValue` + `Add` with `TryAdd` in `ManualDi.Sync/ManualDi.Sync/Building/DiContainerBindings.cs`.
- Updated the logic for multi-binding cases to handle the existing key correctly after a failed `TryAdd` by using the indexer.
- Removed the TODO comment in the Async project that suggested this optimization.
- Ensured consistency between Async and Sync projects.

---
*PR created automatically by Jules for task [2718666897274453442](https://jules.google.com/task/2718666897274453442) started by @PereViader*