### PR TITLE
🧪 Add tests for missing ConstructorDependency exceptions

### DIFF
--- a/ManualDi.Async/ManualDi.Async.Tests/TestConstructorDependency.cs
+++ b/ManualDi.Async/ManualDi.Async.Tests/TestConstructorDependency.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ManualDi.Async.Tests;
+
+public class TestConstructorDependency
+{
+    private class ClassWithDependency
+    {
+        public ClassWithDependency(UnregisteredClass dependency) {}
+    }
+
+    private class UnregisteredClass {}
+
+    [Test]
+    public void TestMissingConstructorDependencyThrowsException()
+    {
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await new DiContainerBindings().Install(b =>
+            {
+                b.Bind<ClassWithDependency>()
+                    .FromMethod(c => new ClassWithDependency(c.Resolve<UnregisteredClass>()))
+                    .DependsOn(d => d.ConstructorDependency<UnregisteredClass>());
+            }).Build(CancellationToken.None);
+        });
+
+        Assert.That(exception!.Message, Does.Contain("is not registered"));
+    }
+
+    [Test]
+    public void TestMissingConstructorDependencyWithFilterThrowsException()
+    {
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await new DiContainerBindings().Install(b =>
+            {
+                b.Bind<ClassWithDependency>()
+                    .FromMethod(c => new ClassWithDependency(c.Resolve<UnregisteredClass>()))
+                    .DependsOn(d => d.ConstructorDependency<UnregisteredClass>(c => true));
+            }).Build(CancellationToken.None);
+        });
+
+        Assert.That(exception!.Message, Does.Contain("with some filter is not registered"));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Adds missing tests to verify that `InvalidOperationException` is correctly thrown when a constructor dependency (unfiltered or filtered) is accessed but not registered in the `DiContainer` during the build process.
📊 **Coverage:** Covers `ConstructorDependency<T>()` and `ConstructorDependency<T>(FilterBindingDelegate filter)` in `DiContainer.cs` for unregistered dependencies, both of which will now throw `InvalidOperationException`.
✨ **Result:** Test coverage for `DiContainer`'s constructor dependency resolution is improved and the specific error scenario explicitly tested.

---
*PR created automatically by Jules for task [15985506094306292963](https://jules.google.com/task/15985506094306292963) started by @PereViader*