### PR TITLE
⚡ Bolt: Optimize reflection caching in DiContainerInvokeExtensions

### DIFF
--- a/ManualDi.Async/ManualDi.Async/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Async/ManualDi.Async/Resolving/DiContainerInvokeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -8,6 +9,10 @@ namespace ManualDi.Async
 {
     public static class DiContainerInvokeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo?> TaskResultPropertyCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableFlagsFieldCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableContextFlagFieldCache = new();
+
         public static object? InvokeDelegateUsingReflexion(this IDiContainer diContainer, Delegate @delegate)
         {
             var arguments = ResolveParameters(diContainer, @delegate);
@@ -22,7 +27,10 @@ namespace ManualDi.Async
                 return result;
             }
             await task;
-            var resultProperty = task.GetType().GetProperty("Result");
+
+            var taskType = task.GetType();
+            var resultProperty = TaskResultPropertyCache.GetOrAdd(taskType, t => t.GetProperty("Result"));
+
             if (resultProperty is null)
             {
                 return null;
@@ -133,9 +141,9 @@ namespace ManualDi.Async
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
+                if (type.Name is "NullableAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
                 {
-                    var field = type.GetField("NullableFlags");
+                    var field = NullableFlagsFieldCache.GetOrAdd(type, t => t.GetField("NullableFlags"));
                     if (field != null)
                     {
                         flags = field.GetValue(attribute) as byte[];
@@ -152,9 +160,9 @@ namespace ManualDi.Async
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
+                if (type.Name is "NullableContextAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
                 {
-                    var field = type.GetField("Flag");
+                    var field = NullableContextFlagFieldCache.GetOrAdd(type, t => t.GetField("Flag"));
                     if (field != null)
                     {
                         context = (byte)field.GetValue(attribute);

--- a/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -8,6 +9,10 @@ namespace ManualDi.Sync
 {
     public static class DiContainerInvokeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo?> TaskResultPropertyCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableFlagsFieldCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableContextFlagFieldCache = new();
+
         public static object? InvokeDelegateUsingReflexion(this IDiContainer diContainer, Delegate @delegate)
         {
             var arguments = ResolveParameters(diContainer, @delegate);
@@ -22,7 +27,10 @@ namespace ManualDi.Sync
                 return result;
             }
             await task;
-            var resultProperty = task.GetType().GetProperty("Result");
+
+            var taskType = task.GetType();
+            var resultProperty = TaskResultPropertyCache.GetOrAdd(taskType, t => t.GetProperty("Result"));
+
             if (resultProperty is null)
             {
                 return null;
@@ -133,9 +141,9 @@ namespace ManualDi.Sync
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
+                if (type.Name is "NullableAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
                 {
-                    var field = type.GetField("NullableFlags");
+                    var field = NullableFlagsFieldCache.GetOrAdd(type, t => t.GetField("NullableFlags"));
                     if (field != null)
                     {
                         flags = field.GetValue(attribute) as byte[];
@@ -152,9 +160,9 @@ namespace ManualDi.Sync
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
+                if (type.Name is "NullableContextAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
                 {
-                    var field = type.GetField("Flag");
+                    var field = NullableContextFlagFieldCache.GetOrAdd(type, t => t.GetField("Flag"));
                     if (field != null)
                     {
                         context = (byte)field.GetValue(attribute);


### PR DESCRIPTION
**💡 What:** 
Introduced `ConcurrentDictionary` caches for frequently requested `PropertyInfo` (`Task.Result`) and `FieldInfo` (`NullableFlags`, `Flag`) instances within `DiContainerInvokeExtensions.cs` in both the `ManualDi.Sync` and `ManualDi.Async` projects. Additionally, implemented an early-return optimization using `type.Name` checks before querying `type.FullName` for Nullable attribute identification.

**🎯 Why:** 
Prior to this change, `DiContainerInvokeExtensions` continuously invoked `task.GetType().GetProperty("Result")` and enumerated custom attributes to find internal Nullable metadata fields. Repeated dynamic reflection without caching in hot resolution pathways incurs high CPU usage and allocates unnecessary memory, creating a significant performance bottleneck during application scaling and dependency graph initialization.

**📊 Impact:**
By replacing costly dynamic reflection lookups with thread-safe cache reads (`GetOrAdd`), CPU overhead during dependency resolution via `InvokeDelegateUsingReflexion` is substantially diminished. The caching pattern and string-check optimizations prevent recurring allocation overhead across DI setups, improving overall initialization times proportional to the number of injected dependencies.

**🔬 Measurement:**
Can be verified via memory profilers and execution tracing. Test suites have been run locally to confirm 100% functionality preservation without regressions across both asynchronous and synchronous execution flows.

---
*PR created automatically by Jules for task [8738968366249857687](https://jules.google.com/task/8738968366249857687) started by @PereViader*