### PR TITLE
⚡ Bolt: Cache reflection in DiContainerInvokeExtensions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Task.Result Property Reflection Caching
+**Learning:** During delegate resolution in `DiContainerInvokeExtensions`, fetching the "Result" property using `task.GetType().GetProperty("Result")` on hot paths introduces significant runtime reflection overhead, particularly in asynchronous flows.
+**Action:** Always employ static caches like `ConcurrentDictionary<Type, PropertyInfo?>` for type-level reflection queries (e.g., `GetProperty`) executed within loops or high-frequency invocations, ensuring thread safety and minimized allocations.

--- a/ManualDi.Async/ManualDi.Async/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Async/ManualDi.Async/Resolving/DiContainerInvokeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -8,6 +9,8 @@ namespace ManualDi.Async
 {
     public static class DiContainerInvokeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo?> TaskResultProperties = new();
+
         public static object? InvokeDelegateUsingReflexion(this IDiContainer diContainer, Delegate @delegate)
         {
             var arguments = ResolveParameters(diContainer, @delegate);
@@ -22,7 +25,13 @@ namespace ManualDi.Async
                 return result;
             }
             await task;
-            var resultProperty = task.GetType().GetProperty("Result");
+            var type = task.GetType();
+            if (!TaskResultProperties.TryGetValue(type, out var resultProperty))
+            {
+                resultProperty = type.GetProperty("Result");
+                TaskResultProperties.TryAdd(type, resultProperty);
+            }
+
             if (resultProperty is null)
             {
                 return null;

--- a/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -8,6 +9,8 @@ namespace ManualDi.Sync
 {
     public static class DiContainerInvokeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo?> TaskResultProperties = new();
+
         public static object? InvokeDelegateUsingReflexion(this IDiContainer diContainer, Delegate @delegate)
         {
             var arguments = ResolveParameters(diContainer, @delegate);
@@ -22,7 +25,13 @@ namespace ManualDi.Sync
                 return result;
             }
             await task;
-            var resultProperty = task.GetType().GetProperty("Result");
+            var type = task.GetType();
+            if (!TaskResultProperties.TryGetValue(type, out var resultProperty))
+            {
+                resultProperty = type.GetProperty("Result");
+                TaskResultProperties.TryAdd(type, resultProperty);
+            }
+
             if (resultProperty is null)
             {
                 return null;


### PR DESCRIPTION
⚡ Bolt: Cache reflection in DiContainerInvokeExtensions

What: Introduce a ConcurrentDictionary cache for PropertyInfo in DiContainerInvokeExtensions to avoid repeated `GetType().GetProperty("Result")` calls.
Why: Calling `GetProperty` dynamically on a generic Task uses runtime reflection, which is incredibly slow in hot paths like delegate parameter resolution.
Impact: Reduces execution time and memory allocations during asynchronous parameter resolution, preventing potential bottlenecks under load.
Measurement: Compare benchmark tests running dependency resolution before and after.

---
*PR created automatically by Jules for task [16089786629899956014](https://jules.google.com/task/16089786629899956014) started by @PereViader*