### PR TITLE
⚡ Bolt: [performance improvement] Cache reflection calls in DiContainerInvokeExtensions

### DIFF
--- a/ManualDi.Async/ManualDi.Async/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Async/ManualDi.Async/Resolving/DiContainerInvokeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -8,6 +9,10 @@ namespace ManualDi.Async
 {
     public static class DiContainerInvokeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo?> ResultPropertyCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableFlagsFieldCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableFlagFieldCache = new();
+
         public static object? InvokeDelegateUsingReflexion(this IDiContainer diContainer, Delegate @delegate)
         {
             var arguments = ResolveParameters(diContainer, @delegate);
@@ -22,7 +27,10 @@ namespace ManualDi.Async
                 return result;
             }
             await task;
-            var resultProperty = task.GetType().GetProperty("Result");
+
+            var taskType = task.GetType();
+            var resultProperty = ResultPropertyCache.GetOrAdd(taskType, t => t.GetProperty("Result"));
+
             if (resultProperty is null)
             {
                 return null;
@@ -133,9 +141,9 @@ namespace ManualDi.Async
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
+                if (type.Name is "NullableAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
                 {
-                    var field = type.GetField("NullableFlags");
+                    var field = NullableFlagsFieldCache.GetOrAdd(type, t => t.GetField("NullableFlags"));
                     if (field != null)
                     {
                         flags = field.GetValue(attribute) as byte[];
@@ -152,9 +160,9 @@ namespace ManualDi.Async
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
+                if (type.Name is "NullableContextAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
                 {
-                    var field = type.GetField("Flag");
+                    var field = NullableFlagFieldCache.GetOrAdd(type, t => t.GetField("Flag"));
                     if (field != null)
                     {
                         context = (byte)field.GetValue(attribute);

--- a/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
+++ b/ManualDi.Sync/ManualDi.Sync/Resolving/DiContainerInvokeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -8,6 +9,10 @@ namespace ManualDi.Sync
 {
     public static class DiContainerInvokeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo?> ResultPropertyCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableFlagsFieldCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo?> NullableFlagFieldCache = new();
+
         public static object? InvokeDelegateUsingReflexion(this IDiContainer diContainer, Delegate @delegate)
         {
             var arguments = ResolveParameters(diContainer, @delegate);
@@ -22,7 +27,10 @@ namespace ManualDi.Sync
                 return result;
             }
             await task;
-            var resultProperty = task.GetType().GetProperty("Result");
+
+            var taskType = task.GetType();
+            var resultProperty = ResultPropertyCache.GetOrAdd(taskType, t => t.GetProperty("Result"));
+
             if (resultProperty is null)
             {
                 return null;
@@ -133,9 +141,9 @@ namespace ManualDi.Sync
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
+                if (type.Name is "NullableAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableAttribute")
                 {
-                    var field = type.GetField("NullableFlags");
+                    var field = NullableFlagsFieldCache.GetOrAdd(type, t => t.GetField("NullableFlags"));
                     if (field != null)
                     {
                         flags = field.GetValue(attribute) as byte[];
@@ -152,9 +160,9 @@ namespace ManualDi.Sync
             foreach (var attribute in attributes)
             {
                 var type = attribute.GetType();
-                if (type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
+                if (type.Name is "NullableContextAttribute" && type.FullName is "System.Runtime.CompilerServices.NullableContextAttribute")
                 {
-                    var field = type.GetField("Flag");
+                    var field = NullableFlagFieldCache.GetOrAdd(type, t => t.GetField("Flag"));
                     if (field != null)
                     {
                         context = (byte)field.GetValue(attribute);


### PR DESCRIPTION
💡 What: Caches the `PropertyInfo` for `Task.Result` and `FieldInfo` for Nullable-related fields using `ConcurrentDictionary`, and adds a fast-path `.Name` check before checking `.FullName` for attributes.
🎯 Why: Reflection calls (`GetProperty`, `GetField`, `FullName`) are slow and allocate memory. Doing this on a hot path like DI resolution causes unnecessary overhead.
📊 Impact: Significantly reduces allocations and CPU overhead during asynchronous container resolution and parameter injection.
🔬 Measurement: Can be verified by running the existing `ManualDi.Async.Benchmark` project.

---
*PR created automatically by Jules for task [7964066194015806835](https://jules.google.com/task/7964066194015806835) started by @PereViader*