### PR TITLE
🧪 [Test Improvement] Async DiContainerBindings Error Path Coverage

### DIFF
--- a/ManualDi.Async/ManualDi.Async.Tests/TestDiContainerBindingsError.cs
+++ b/ManualDi.Async/ManualDi.Async.Tests/TestDiContainerBindingsError.cs
@@ -1,0 +1,91 @@
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ManualDi.Async.Tests;
+
+public class TestDiContainerBindingsError
+{
+    private class BuildException : Exception { }
+    private class DisposeException : Exception { }
+
+    [Test]
+    public async Task TestBuildExceptionAndDisposeException()
+    {
+        var buildException = new BuildException();
+        var disposeException = new DisposeException();
+
+        var bindings = new DiContainerBindings()
+            .Install(b =>
+            {
+                b.QueueInitialize((_) => throw buildException);
+                b.QueueDispose(() => throw disposeException);
+            });
+
+        try
+        {
+            await bindings.Build(CancellationToken.None);
+            Assert.Fail("Expected an AggregateException to be thrown.");
+        }
+        catch (AggregateException aggregateException)
+        {
+            Assert.That(aggregateException, Is.Not.Null);
+            Assert.That(aggregateException!.InnerExceptions, Has.Count.EqualTo(2));
+            Assert.That(aggregateException.InnerExceptions[0], Is.SameAs(buildException));
+            Assert.That(aggregateException.InnerExceptions[1], Is.SameAs(disposeException));
+        }
+    }
+
+    [Test]
+    public async Task TestBuildExceptionNoDisposeException()
+    {
+        var buildException = new BuildException();
+        var disposeAction = Substitute.For<Action>();
+
+        var bindings = new DiContainerBindings()
+            .Install(b =>
+            {
+                b.QueueInitialize((_) => throw buildException);
+                b.QueueDispose(disposeAction);
+            });
+
+        try
+        {
+            await bindings.Build(CancellationToken.None);
+            Assert.Fail("Expected a BuildException to be thrown.");
+        }
+        catch (BuildException thrownException)
+        {
+            Assert.That(thrownException, Is.SameAs(buildException));
+            disposeAction.Received(1).Invoke();
+        }
+    }
+
+    [Test]
+    public async Task TestFailureDebugReportAttached()
+    {
+        var buildException = new BuildException();
+
+        var bindings = new DiContainerBindings()
+            .Install(b =>
+            {
+                b.QueueInitialize((_) => throw buildException);
+            })
+            .WithFailureDebugReport();
+
+        try
+        {
+            await bindings.Build(CancellationToken.None);
+            Assert.Fail("Expected a BuildException to be thrown.");
+        }
+        catch (BuildException thrownException)
+        {
+            Assert.That(thrownException, Is.SameAs(buildException));
+            Assert.That(thrownException.Data.Contains(DiContainer.FailureDebugReportKey), Is.True);
+            var report = thrownException.Data[DiContainer.FailureDebugReportKey] as string;
+            Assert.That(report, Is.Not.Null);
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Adds missing test coverage for `DiContainerBindings` error paths in the `ManualDi.Async` project. Covers the scenarios where a build operation fails and subsequently triggers a dispose loop, verifying that standard exceptions and `AggregateException`s are appropriately created and dispatched, and ensuring failure debug reports are accurately appended when configured.

📊 **Coverage:**
- Exceptions thrown during `Build` combined with secondary exceptions thrown during the error-recovery `DisposeAsync`.
- Exceptions thrown during `Build` when the subsequent `DisposeAsync` successfully recovers without further issues.
- Verification that when `failureDebugReportEnabled` is set, the exception possesses the report data matching `DiContainer.FailureDebugReportKey`.

✨ **Result:** Solidifies testing architecture mapping the edge-cases inside the try/catch unrolling logic. Asserts correct inner exceptions inside aggregate responses. Improves confidence around safety of concurrent DI building.

---
*PR created automatically by Jules for task [14807081910832901222](https://jules.google.com/task/14807081910832901222) started by @PereViader*